### PR TITLE
Make the binary more portable by disabling CGO when building.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
       run: |
         export GOOS=${{ matrix.os }}
         export GOARCH=${{ matrix.arch }}
-        go build -o fmeserver${{ matrix.exe-ext }} -ldflags="-X \"github.com/safesoftware/fmeserver-cli/cmd.appVersion=${{ env.APP_VERSION }}\""
+        CGO_ENABLED=0 go build -o fmeserver${{ matrix.exe-ext }} -ldflags="-X \"github.com/safesoftware/fmeserver-cli/cmd.appVersion=${{ env.APP_VERSION }}\""
 
     - name: Upload artifact for later steps
       uses: actions/upload-artifact@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,5 +18,8 @@ jobs:
       with:
         go-version: 1.19
 
+    - name: Test build
+      run: CGO_ENABLED=0 go build -o fmeserver -ldflags="-X \"github.com/safesoftware/fmeserver-cli/cmd.appVersion=$(echo ${GITHUB_REF} | rev | cut -d'/' -f 1 | rev )\""
+
     - name: Run tests
       run: go test ./...


### PR DESCRIPTION
Since we don't rely on CGO, we should remove the dependency on glibc and produce a static binary.