### PR TITLE
Fix permissions on config directory if it needs to be created

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -220,7 +220,7 @@ func loginRun(f *loginFlags) func(cmd *cobra.Command, args []string) error {
 		}
 		viper.Set("build", buildNum)
 		// ensure directory where config file is supposed to live exists
-		err = os.MkdirAll(filepath.Dir(viper.ConfigFileUsed()), 0600)
+		err = os.MkdirAll(filepath.Dir(viper.ConfigFileUsed()), 0700)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This causes an issue on machines where the config directory doesn't exist. The execute permission is needed on the directory or the creation of the config file fails.